### PR TITLE
Fix HppManipulationGraphWidget::showNodeOfConfiguration

### DIFF
--- a/src/hpp-manipulation-graph.cc
+++ b/src/hpp-manipulation-graph.cc
@@ -226,7 +226,7 @@ namespace hpp {
           scene_->update();
         } else {
           qDebug() << "Node" << showNodeId_ << "does not exist. Refer the graph may solve the issue.";
-          showNodeId_ = 0;
+          showNodeId_ = -1;
         }
       } catch (const hpp::Error& e) {
         qDebug() << QString(e.msg);


### PR DESCRIPTION
The first fix was still buggy, when the node doesn't exists, showNodeId_ need to be equal to -1.